### PR TITLE
feat: close the read gaps blocking Terraform parity

### DIFF
--- a/pkg/client/ai_processors.go
+++ b/pkg/client/ai_processors.go
@@ -1,7 +1,6 @@
 package client
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -312,27 +311,7 @@ func (c *Client) ListAIProcessorHistory(
 	if err := c.doRequest(ctx, "GET", endpoint, nil, &raw); err != nil {
 		return nil, err
 	}
-
-	// The route paginates, so the entries normally arrive inside the standard envelope. Sniff
-	// the shape rather than assuming it: the view only wraps its results while a paginator is
-	// configured, and pagination is an instance-wide setting an on-prem deployment can turn
-	// off, which would otherwise leave this failing to decode at all.
-	trimmed := bytes.TrimSpace(raw)
-	if len(trimmed) > 0 && trimmed[0] == '[' {
-		var entries []AIProcessorHistoryEntry
-		if err := json.Unmarshal(trimmed, &entries); err != nil {
-			return nil, fmt.Errorf("failed to decode AI processor history: %w", err)
-		}
-		return entries, nil
-	}
-
-	var envelope struct {
-		Results []AIProcessorHistoryEntry `json:"results"`
-	}
-	if err := json.Unmarshal(trimmed, &envelope); err != nil {
-		return nil, fmt.Errorf("failed to decode AI processor history envelope: %w", err)
-	}
-	return envelope.Results, nil
+	return decodeHistoryList[AIProcessorHistoryEntry](raw, "AI processor")
 }
 
 // FindAIProcessor returns the processor for a (service, action type) pair - the pair the platform

--- a/pkg/client/change_instance.go
+++ b/pkg/client/change_instance.go
@@ -28,6 +28,13 @@ const (
 type GetChangeInstancesRequest struct {
 	// The POV (point of view) is used to determine the API path(serviceowner or consumer).
 	POV string `json:"pov"`
+	// ApplicationID is the ID of the application owning the change instance's service item.
+	// Comma-join several to get an "in" lookup (an OR), as with the other id filters here.
+	//
+	// This is the filter a per-application view needs: a change instance carries no direct
+	// link to an application, so without it a caller has to list every change instance and
+	// sift them client-side.
+	ApplicationID string `json:"application_id"`
 	// ChangeType is the type of change instance (e.g., "CREATE", "UPDATE", "DELETE").
 	ChangeType string `json:"change_type"`
 	// CommitID is the ID of the commit associated with the submission.
@@ -40,6 +47,8 @@ type GetChangeInstancesRequest struct {
 	DeclarationContains string `json:"declaration_contains"`
 	// DeclarationRegex is a regex pattern to match against the declaration.
 	DeclarationRegex string `json:"declaration_regex"`
+	// EndDate restricts results to change instances modified at or before this time.
+	EndDate time.Time `json:"end_date"`
 	// ExcludeReferenced indicates whether to exclude referenced change instances.
 	ExcludeReferenced bool `json:"exclude_referenced"`
 	// Limit is the maximum number of results to return per page.
@@ -58,6 +67,11 @@ type GetChangeInstancesRequest struct {
 	ServiceName string `json:"service_name"`
 	// ServiceOwnerTeamID is the ID of the service owner team associated with the change instance.
 	ServiceOwnerTeamID string `json:"service_owner_team_id"`
+	// StartDate restricts results to change instances modified at or after this time. It is
+	// the same lower bound Modified already applies - the backend declares both against
+	// modified with a gte lookup - and exists so a window can be expressed as one pair of
+	// fields alongside EndDate. Set one or the other, not both.
+	StartDate time.Time `json:"start_date"`
 	// State is the state of the change instance (e.g., "PENDING", "APPROVED", "REJECTED").
 	State string `json:"state"`
 	// SubmissionID is the ID of the submission associated with the change instance.
@@ -65,9 +79,14 @@ type GetChangeInstancesRequest struct {
 }
 
 // ToQueryParams converts the GetChangeInstancesRequest fields into a URL-encoded query string.
+//
+//nolint:funlen // one flat branch per filter; splitting it would only hide which filters exist
 func (r *GetChangeInstancesRequest) ToQueryParams() (string, error) {
 	params := url.Values{}
 
+	if r.ApplicationID != "" {
+		params.Add("application_id", r.ApplicationID)
+	}
 	if r.ChangeType != "" {
 		params.Add("change_type", r.ChangeType)
 	}
@@ -85,6 +104,9 @@ func (r *GetChangeInstancesRequest) ToQueryParams() (string, error) {
 	}
 	if r.DeclarationRegex != "" {
 		params.Add("declaration_regex", r.DeclarationRegex)
+	}
+	if !r.EndDate.IsZero() {
+		params.Add("end_date", r.EndDate.Format(time.RFC3339))
 	}
 	if r.ExcludeReferenced {
 		params.Add("exclude_referenced", strconv.FormatBool(r.ExcludeReferenced))
@@ -112,6 +134,9 @@ func (r *GetChangeInstancesRequest) ToQueryParams() (string, error) {
 	}
 	if r.ServiceOwnerTeamID != "" {
 		params.Add("service_owner_team_id", r.ServiceOwnerTeamID)
+	}
+	if !r.StartDate.IsZero() {
+		params.Add("start_date", r.StartDate.Format(time.RFC3339))
 	}
 	if r.State != "" {
 		params.Add("state", r.State)
@@ -227,6 +252,53 @@ func (c *Client) GetChangeInstancesWithContext(
 	ctx context.Context,
 	filters *GetChangeInstancesRequest,
 ) (*GetChangeInstancesResponse, error) {
+	return c.listChangeInstances(ctx, filters, "")
+}
+
+// GetDependantChangeInstances fetches the change instances raised against services your team
+// owns but handed to a different team to fulfil - the copies your dependant teams are working
+// on, which the plain listing hides because it only shows changes your own team owns.
+//
+// This is the main team's view of its dependants' progress, and so is the mirror image of
+// GetDependantServiceItems, which shows the items where your team is itself the dependant.
+//
+// It takes the same filters and returns the same paginated shape as
+// GetChangeInstancesWithContext, except that the backend swaps out the whole filter backend
+// chain on this route, dropping the ordering backend with it - so Ordering is accepted but has
+// no effect here.
+func (c *Client) GetDependantChangeInstances(
+	ctx context.Context,
+	filters *GetChangeInstancesRequest,
+) (*GetChangeInstancesResponse, error) {
+	return c.listChangeInstances(ctx, filters, "dependant/")
+}
+
+// GetReferencedChangeInstances fetches the referenced change instances your team can see: those
+// raised on somebody else's service item because it names one of your items in its related list.
+//
+// When a consumer's load balancer declares your virtual machine as related, a change to that
+// machine raises a MODIFY change on the load balancer. That change belongs to the load
+// balancer's service owner, not to you, so it never appears in your plain listing - but you are
+// the reason it exists, and this route is how you see it.
+//
+// It is the complement of the ExcludeReferenced filter, which removes exactly this class of
+// change from the plain listing. The same ordering caveat as GetDependantChangeInstances
+// applies.
+func (c *Client) GetReferencedChangeInstances(
+	ctx context.Context,
+	filters *GetChangeInstancesRequest,
+) (*GetChangeInstancesResponse, error) {
+	return c.listChangeInstances(ctx, filters, "referenced/")
+}
+
+// listChangeInstances performs one change instance listing, against either the plain route (an
+// empty action) or one of its extra list routes. They share a filter set and a response shape,
+// so the only thing that varies is the path segment.
+func (c *Client) listChangeInstances(
+	ctx context.Context,
+	filters *GetChangeInstancesRequest,
+	action string,
+) (*GetChangeInstancesResponse, error) {
 	if filters == nil {
 		filters = &GetChangeInstancesRequest{}
 	}
@@ -239,7 +311,7 @@ func (c *Client) GetChangeInstancesWithContext(
 
 	// The trailing slash is the canonical DRF route; without it the API replies 301 to the
 	// slashed URL, doubling the round trips.
-	endpoint := fmt.Sprintf("orcabase/%s/change_instances/", POV(filters.POV).orDefault())
+	endpoint := fmt.Sprintf("orcabase/%s/change_instances/%s", POV(filters.POV).orDefault(), action)
 	if params != "" {
 		endpoint += "?" + params
 	}
@@ -264,6 +336,54 @@ func (c *Client) GetChangeInstance(ctx context.Context, pov POV, id int) (*Chang
 		return nil, err
 	}
 	return &response, nil
+}
+
+// ChangeInstanceHistoryEntry is one recorded step in a change instance's life.
+//
+// The platform tracks only state and log changes, so the trail is a record of decisions - who
+// approved or rejected the change and why - rather than of every field it touched along the way.
+type ChangeInstanceHistoryEntry struct {
+	// ID is the change instance the entry belongs to, not the entry's own identifier: the
+	// platform serialises the tracked object's id, so every entry in one trail repeats it.
+	// Entries are told apart by Modified and Reason.
+	ID int `json:"id"`
+	// State is the state the change held at this point, rendered as its name ("PENDING",
+	// "APPROVED") rather than the integer the database stores.
+	State string `json:"state"`
+	// Log is the message recorded with the transition - the explanation a consumer reads when
+	// their request is rejected. Empty when the transition carried none.
+	Log string `json:"log"`
+	// Modified is when the entry was recorded. Entries arrive newest first.
+	Modified time.Time `json:"modified"`
+	// Reason is which of the two tracked fields moved: "state" or "log".
+	Reason string `json:"reason"`
+	// ChangedBy is the username behind the change, or an API key's name suffixed " (Api Key)"
+	// when a key made it. It reads "SYSTEM" for a transition the platform made itself.
+	ChangedBy *string `json:"changed_by"`
+	// ChangedByTeam is the team the actor was acting for, nil when the platform cannot
+	// attribute the change to one - a user who has since left the team, for instance.
+	ChangedByTeam *string `json:"changed_by_team"`
+}
+
+// ListChangeInstanceHistory returns a change instance's state and log history, newest first.
+//
+// This is the audit trail behind a change: who approved or rejected it, when, and with what
+// explanation. It is the only way to recover a superseded log message, because a later
+// transition overwrites the change's own Log field.
+//
+// It returns an error wrapping ErrNotFound when no such change exists.
+func (c *Client) ListChangeInstanceHistory(
+	ctx context.Context,
+	pov POV,
+	id int,
+) ([]ChangeInstanceHistoryEntry, error) {
+	endpoint := fmt.Sprintf("orcabase/%s/change_instances/%d/history/", pov.orDefault(), id)
+
+	var raw json.RawMessage
+	if err := c.doRequest(ctx, "GET", endpoint, nil, &raw); err != nil {
+		return nil, err
+	}
+	return decodeHistoryList[ChangeInstanceHistoryEntry](raw, "change instance")
 }
 
 // ApproveChangeInstance approves a change instance by updating its state to "APPROVED".

--- a/pkg/client/change_instance_test.go
+++ b/pkg/client/change_instance_test.go
@@ -2,7 +2,9 @@
 package client_test
 
 import (
+	"context"
 	"encoding/json"
+	"net/http"
 	"testing"
 	"time"
 
@@ -13,6 +15,34 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const changeInstancesRoot = packTestBaseURL + "/v1/orcabase/serviceowner/change_instances"
+
+// changeInstanceHistory is the trail of a change raised by a consumer, approved by a service
+// owner's API key with a note, then completed by the platform itself. It shows the three things
+// about the shape a caller has to know: id repeats (it is the change's id, not the entry's),
+// changed_by reads "SYSTEM" for a platform transition, and changed_by_team can be null.
+const changeInstanceHistory = `[
+  {
+    "id": 7,
+    "state": "COMPLETED",
+    "log": "Deployed to lon-dc1.",
+    "modified": "2026-07-19T14:03:00Z",
+    "reason": "state",
+    "changed_by": "SYSTEM",
+    "changed_by_team": null
+  },
+  {
+    "id": 7,
+    "state": "APPROVED",
+    "log": "Capacity confirmed.",
+    "modified": "2026-07-19T11:20:00Z",
+    "reason": "state",
+    "changed_by": "terraform-key (Api Key)",
+    "changed_by_team": "AWS"
+  }
+]`
+
+//nolint:funlen // a filter table: every case has to spell out the fields it is pinning
 func TestChangeInstancesToQueryParams(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -23,12 +53,14 @@ func TestChangeInstancesToQueryParams(t *testing.T) {
 			name: "All fields set",
 			request: &client.GetChangeInstancesRequest{
 				POV:                 "pov", // will be ignored
+				ApplicationID:       "app-id",
 				ChangeType:          "type",
 				CommitID:            "commit-id",
 				ConsumerTeamID:      "team-id",
 				Declaration:         "declaration",
 				DeclarationContains: "contains",
 				DeclarationRegex:    "regex",
+				EndDate:             time.Date(2025, 4, 30, 0, 0, 0, 0, time.UTC),
 				ExcludeReferenced:   true,
 				Limit:               10,
 				Modified:            time.Date(2025, 4, 9, 11, 11, 4, 194909000, time.UTC),
@@ -37,10 +69,11 @@ func TestChangeInstancesToQueryParams(t *testing.T) {
 				ServiceItemID:       "item-id",
 				ServiceName:         "service-name",
 				ServiceOwnerTeamID:  "team-owner-id",
+				StartDate:           time.Date(2025, 4, 1, 0, 0, 0, 0, time.UTC),
 				State:               "state",
 				SubmissionID:        "submission-id",
 			},
-			expected: "change_type=type&commit_id=commit-id&consumer_team_id=team-id&declaration=declaration&declaration_contains=contains&declaration_regex=regex&exclude_referenced=true&limit=10&modified=2025-04-09T11%3A11%3A04Z&service_id=service-id&service_item_id=item-id&service_name=service-name&service_owner_team_id=team-owner-id&state=state&submission_id=submission-id", //nolint
+			expected: "application_id=app-id&change_type=type&commit_id=commit-id&consumer_team_id=team-id&declaration=declaration&declaration_contains=contains&declaration_regex=regex&end_date=2025-04-30T00%3A00%3A00Z&exclude_referenced=true&limit=10&modified=2025-04-09T11%3A11%3A04Z&service_id=service-id&service_item_id=item-id&service_name=service-name&service_owner_team_id=team-owner-id&start_date=2025-04-01T00%3A00%3A00Z&state=state&submission_id=submission-id", //nolint
 		},
 		{
 			name:     "No fields set",
@@ -700,5 +733,224 @@ func TestUpdateChangeInstanceOptionalFields(t *testing.T) {
 
 		require.NoError(t, err)
 		assert.JSONEq(t, `{"state":"COMPLETED","log":"deployed","deployed_item":{"vip":"10.1.1.1"}}`, capturedBody)
+	})
+}
+
+// TestGetChangeInstancesFilterWire pins the new filters to the wire. The backend's filterset
+// rejects any parameter it does not declare with a 400, so the names matter as much as the
+// values - and application_id in particular had no way of being sent at all before.
+func TestGetChangeInstancesFilterWire(t *testing.T) {
+	t.Run("sends application_id and the modified window", func(t *testing.T) {
+		httpmock.Activate()
+		defer httpmock.DeactivateAndReset()
+
+		var capturedQuery string
+		httpmock.RegisterResponder("GET", changeInstancesRoot+"/",
+			func(req *http.Request) (*http.Response, error) {
+				capturedQuery = req.URL.RawQuery
+				return httpmock.NewStringResponse(200, emptyPage), nil
+			})
+
+		nc := newPackTestClient(t)
+		_, err := nc.GetChangeInstancesWithContext(context.Background(), &client.GetChangeInstancesRequest{
+			ApplicationID: "23,24",
+			StartDate:     time.Date(2025, 4, 1, 0, 0, 0, 0, time.UTC),
+			EndDate:       time.Date(2025, 4, 30, 0, 0, 0, 0, time.UTC),
+		})
+
+		require.NoError(t, err)
+		// A comma-joined value is the platform's "in" lookup, so this asks for either.
+		assert.Contains(t, capturedQuery, "application_id=23%2C24")
+		assert.Contains(t, capturedQuery, "start_date=2025-04-01T00%3A00%3A00Z")
+		assert.Contains(t, capturedQuery, "end_date=2025-04-30T00%3A00%3A00Z")
+	})
+
+	t.Run("omits the date filters when unset", func(t *testing.T) {
+		httpmock.Activate()
+		defer httpmock.DeactivateAndReset()
+
+		var capturedQuery string
+		httpmock.RegisterResponder("GET", changeInstancesRoot+"/",
+			func(req *http.Request) (*http.Response, error) {
+				capturedQuery = req.URL.RawQuery
+				return httpmock.NewStringResponse(200, emptyPage), nil
+			})
+
+		nc := newPackTestClient(t)
+		_, err := nc.GetChangeInstancesWithContext(context.Background(), &client.GetChangeInstancesRequest{
+			State: "PENDING",
+		})
+
+		require.NoError(t, err)
+		// A zero time is "unset", not the epoch - sending it would bound the window at 1970
+		// and quietly drop everything.
+		assert.NotContains(t, capturedQuery, "start_date")
+		assert.NotContains(t, capturedQuery, "end_date")
+	})
+}
+
+func TestGetDependantChangeInstances(t *testing.T) {
+	t.Run("queries the dependant route carrying the filters", func(t *testing.T) {
+		httpmock.Activate()
+		defer httpmock.DeactivateAndReset()
+
+		var capturedQuery string
+		httpmock.RegisterResponder("GET", changeInstancesRoot+"/dependant/",
+			func(req *http.Request) (*http.Response, error) {
+				capturedQuery = req.URL.RawQuery
+				return httpmock.NewStringResponse(200, emptyPage), nil
+			})
+
+		nc := newPackTestClient(t)
+		resp, err := nc.GetDependantChangeInstances(context.Background(), &client.GetChangeInstancesRequest{
+			ApplicationID: "23",
+			State:         "PENDING",
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, 0, resp.Count)
+		// The extra route shares the plain listing's filterset, so the filters must survive
+		// the detour rather than being dropped on the way.
+		assert.Contains(t, capturedQuery, "application_id=23")
+		assert.Contains(t, capturedQuery, "state=PENDING")
+	})
+
+	t.Run("defaults an empty POV to serviceowner", func(t *testing.T) {
+		httpmock.Activate()
+		defer httpmock.DeactivateAndReset()
+
+		httpmock.RegisterResponder("GET", changeInstancesRoot+"/dependant/",
+			httpmock.NewStringResponder(200, emptyPage))
+
+		nc := newPackTestClient(t)
+		_, err := nc.GetDependantChangeInstances(context.Background(), nil)
+
+		require.NoError(t, err)
+	})
+}
+
+func TestGetReferencedChangeInstances(t *testing.T) {
+	t.Run("queries the referenced route carrying the filters", func(t *testing.T) {
+		httpmock.Activate()
+		defer httpmock.DeactivateAndReset()
+
+		var capturedQuery string
+		httpmock.RegisterResponder("GET", changeInstancesRoot+"/referenced/",
+			func(req *http.Request) (*http.Response, error) {
+				capturedQuery = req.URL.RawQuery
+				return httpmock.NewStringResponse(200, emptyPage), nil
+			})
+
+		nc := newPackTestClient(t)
+		_, err := nc.GetReferencedChangeInstances(context.Background(), &client.GetChangeInstancesRequest{
+			ServiceItemID: "389",
+			Limit:         25,
+		})
+
+		require.NoError(t, err)
+		assert.Contains(t, capturedQuery, "service_item_id=389")
+		assert.Contains(t, capturedQuery, "limit=25")
+	})
+
+	t.Run("honours a consumer POV", func(t *testing.T) {
+		httpmock.Activate()
+		defer httpmock.DeactivateAndReset()
+
+		httpmock.RegisterResponder("GET", packTestBaseURL+"/v1/orcabase/consumer/change_instances/referenced/",
+			httpmock.NewStringResponder(200, emptyPage))
+
+		nc := newPackTestClient(t)
+		_, err := nc.GetReferencedChangeInstances(context.Background(), &client.GetChangeInstancesRequest{
+			POV: string(client.POVConsumer),
+		})
+
+		require.NoError(t, err)
+	})
+}
+
+//nolint:funlen // four subtests over one fixture; splitting them would scatter the shape assertions
+func TestListChangeInstanceHistory(t *testing.T) {
+	t.Run("decodes the paginated envelope the route normally returns", func(t *testing.T) {
+		httpmock.Activate()
+		defer httpmock.DeactivateAndReset()
+
+		var capturedPath string
+		httpmock.RegisterResponder("GET", changeInstancesRoot+"/7/history/",
+			func(req *http.Request) (*http.Response, error) {
+				capturedPath = req.URL.Path
+				body := `{"count":2,"next":null,"previous":null,"results":` + changeInstanceHistory + `}`
+				return httpmock.NewStringResponse(200, body), nil
+			})
+
+		nc := newPackTestClient(t)
+		entries, err := nc.ListChangeInstanceHistory(context.Background(), client.POVServiceOwner, 7)
+
+		require.NoError(t, err)
+		// The id belongs once in the path. Repeating it, as the Python SDK does, gives a
+		// route that does not exist.
+		assert.Equal(t, "/v1/orcabase/serviceowner/change_instances/7/history/", capturedPath)
+
+		require.Len(t, entries, 2)
+		// Entries arrive newest first, and every one repeats the change's id rather than
+		// carrying an identifier of its own.
+		assert.Equal(t, "COMPLETED", entries[0].State)
+		assert.Equal(t, 7, entries[0].ID)
+		assert.Equal(t, 7, entries[1].ID)
+		assert.Equal(t, "Capacity confirmed.", entries[1].Log)
+
+		// A platform transition is attributed to nobody's team, which is why the field is
+		// a pointer rather than a string.
+		require.NotNil(t, entries[0].ChangedBy)
+		assert.Equal(t, "SYSTEM", *entries[0].ChangedBy)
+		assert.Nil(t, entries[0].ChangedByTeam)
+		require.NotNil(t, entries[1].ChangedByTeam)
+		assert.Equal(t, "AWS", *entries[1].ChangedByTeam)
+	})
+
+	t.Run("decodes a bare array when pagination is switched off", func(t *testing.T) {
+		httpmock.Activate()
+		defer httpmock.DeactivateAndReset()
+
+		// An on-prem deployment can turn the paginator off instance-wide, at which point
+		// the view stops wrapping its results.
+		httpmock.RegisterResponder("GET", changeInstancesRoot+"/7/history/",
+			httpmock.NewStringResponder(200, changeInstanceHistory))
+
+		nc := newPackTestClient(t)
+		entries, err := nc.ListChangeInstanceHistory(context.Background(), client.POVServiceOwner, 7)
+
+		require.NoError(t, err)
+		require.Len(t, entries, 2)
+		assert.Equal(t, "APPROVED", entries[1].State)
+		assert.Equal(t, "state", entries[1].Reason)
+	})
+
+	t.Run("defaults an empty POV to serviceowner", func(t *testing.T) {
+		httpmock.Activate()
+		defer httpmock.DeactivateAndReset()
+
+		httpmock.RegisterResponder("GET", changeInstancesRoot+"/7/history/",
+			httpmock.NewStringResponder(200, `[]`))
+
+		nc := newPackTestClient(t)
+		entries, err := nc.ListChangeInstanceHistory(context.Background(), "", 7)
+
+		require.NoError(t, err)
+		assert.Empty(t, entries)
+	})
+
+	t.Run("surfaces a missing change as ErrNotFound", func(t *testing.T) {
+		httpmock.Activate()
+		defer httpmock.DeactivateAndReset()
+
+		httpmock.RegisterResponder("GET", changeInstancesRoot+"/999999/history/",
+			httpmock.NewStringResponder(404, `{"detail":"Not found."}`))
+
+		nc := newPackTestClient(t)
+		entries, err := nc.ListChangeInstanceHistory(context.Background(), client.POVServiceOwner, 999999)
+
+		require.Error(t, err)
+		assert.Nil(t, entries)
+		require.ErrorIs(t, err, client.ErrNotFound)
 	})
 }

--- a/pkg/client/pack.go
+++ b/pkg/client/pack.go
@@ -171,6 +171,90 @@ func (c *Client) GetPackData(
 	return &response, nil
 }
 
+// GetPackDataByID returns a single pack data record by its own id, rather than by the object and
+// stage it belongs to.
+//
+// Use it to re-read a record whose id you already hold - one embedded in a pipeline run, or one
+// PushPackData just returned - which is how a caller reads back exactly the record it saw rather
+// than whatever the stage's newest has since become.
+//
+// Unlike GetPackData, a 404 here is a plain error wrapping ErrNotFound and not
+// ErrPackDataNotFound: an unknown id is a bad reference, whereas a stage with no data yet is a
+// normal phase of a running pipeline, and the two should not be handled alike.
+func (c *Client) GetPackDataByID(ctx context.Context, pov POV, id int) (*PackData, error) {
+	endpoint := fmt.Sprintf("external/%s/pack/data/%d/", pov.orDefault(), id)
+
+	var response PackData
+	if err := c.doRequest(ctx, "GET", endpoint, nil, &response); err != nil {
+		return nil, err
+	}
+	return &response, nil
+}
+
+// ListPackDataRequest paginates a pack data listing.
+//
+// There is deliberately nothing to filter on. The pack data view declares no filterset, so the
+// platform silently ignores every query parameter beyond the paginator's limit and offset and
+// the ordering backend's ordering - a filter sent here is dropped rather than rejected, which is
+// worse than an error because the caller gets a plausible, unfiltered answer back. Narrow the
+// results with Ordering and Limit, or use GetPackData when you know the object and stage.
+type ListPackDataRequest struct {
+	// POV is the point of view to query from. Defaults to serviceowner.
+	POV POV
+	// Limit caps the number of results returned. Zero means no cap.
+	Limit int
+	// Offset skips this many results.
+	Offset int
+	// Ordering names the field to sort by; prefix with "-" to reverse. "-created" is the
+	// useful one: it puts the newest records first.
+	Ordering string
+}
+
+// ToQueryParams renders the pagination parameters as a percent-encoded query string, "" when
+// empty. It cannot fail, unlike its siblings, because nothing here needs encoding as JSON.
+func (r *ListPackDataRequest) ToQueryParams() string {
+	params := newQueryParams()
+	params.SetInt("limit", r.Limit)
+	params.SetInt("offset", r.Offset)
+	params.SetString("ordering", r.Ordering)
+	return params.Encode()
+}
+
+// ListPackDataResponse is the paginated envelope the API returns for a pack data listing.
+type ListPackDataResponse struct {
+	// Count is the total number of records visible to the API key, across all pages.
+	Count int `json:"count"`
+	// Next is the URL of the next page, nil on the last page.
+	Next *string `json:"next"`
+	// Previous is the URL of the previous page, nil on the first page.
+	Previous *string `json:"previous"`
+	// Results is this page of records.
+	Results []PackData `json:"results"`
+}
+
+// ListPackData returns pack data records across every object and stage the API key can see,
+// newest-first if you ask for it with Ordering.
+//
+// The listing is unfiltered by design (see ListPackDataRequest), so it is a sweep rather than a
+// lookup: reach for it to audit what the pipelines have produced recently, and for a specific
+// object's stage use GetPackData, which asks the platform to do the narrowing.
+func (c *Client) ListPackData(
+	ctx context.Context,
+	filters *ListPackDataRequest,
+) (*ListPackDataResponse, error) {
+	if filters == nil {
+		filters = &ListPackDataRequest{}
+	}
+
+	endpoint := fmt.Sprintf("external/%s/pack/data/%s", filters.POV.orDefault(), filters.ToQueryParams())
+
+	var response ListPackDataResponse
+	if err := c.doRequest(ctx, "GET", endpoint, nil, &response); err != nil {
+		return nil, err
+	}
+	return &response, nil
+}
+
 // PushPackData writes stage data into a pack pipeline - how an external executor reports the
 // outcome of work the platform delegated to it.
 //

--- a/pkg/client/pack_test.go
+++ b/pkg/client/pack_test.go
@@ -1,6 +1,7 @@
 package client_test
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -173,5 +174,113 @@ func TestClientRetriggerPack(t *testing.T) {
 		require.Error(t, err)
 		assert.Empty(t, msg)
 		assert.Contains(t, err.Error(), "400 Bad Request")
+	})
+}
+
+const packDataRoot = packTestBaseURL + "/v1/external/serviceowner/pack/data"
+
+// onePackDataRecord is a config stage payload as the API returns it, scope envelope and all.
+const onePackDataRecord = `{
+  "id": 6600,
+  "created": "2026-07-19T10:11:12Z",
+  "modified": "2026-07-19T10:11:12Z",
+  "action_type": "config",
+  "object_id": 389,
+  "data": {"as3_json": {"id": "vs_demo"}},
+  "scope": {"scope": "service_item", "data": {"id": 389, "name": "demo"}}
+}`
+
+func TestGetPackDataByID(t *testing.T) {
+	t.Run("returns one record by its own id", func(t *testing.T) {
+		httpmock.Activate()
+		defer httpmock.DeactivateAndReset()
+
+		httpmock.RegisterResponder("GET", packDataRoot+"/6600/",
+			httpmock.NewStringResponder(200, onePackDataRecord))
+
+		nc := newPackTestClient(t)
+		data, err := nc.GetPackDataByID(context.Background(), client.POVServiceOwner, 6600)
+
+		require.NoError(t, err)
+		assert.Equal(t, 6600, data.ID)
+		assert.Equal(t, 389, data.ObjectID)
+		assert.Equal(t, client.PackScopeServiceItem, data.ScopeKind())
+	})
+
+	t.Run("surfaces an unknown id as ErrNotFound rather than ErrPackDataNotFound", func(t *testing.T) {
+		httpmock.Activate()
+		defer httpmock.DeactivateAndReset()
+
+		httpmock.RegisterResponder("GET", packDataRoot+"/999999/",
+			httpmock.NewStringResponder(404, `{"detail":"Not found."}`))
+
+		nc := newPackTestClient(t)
+		data, err := nc.GetPackDataByID(context.Background(), client.POVServiceOwner, 999999)
+
+		require.Error(t, err)
+		assert.Nil(t, data)
+		// A bad id is a bad reference. Only the scoped getter treats a 404 as "the stage
+		// has not run yet", which is a normal phase rather than a mistake.
+		require.ErrorIs(t, err, client.ErrNotFound)
+		require.NotErrorIs(t, err, client.ErrPackDataNotFound)
+	})
+}
+
+func TestListPackData(t *testing.T) {
+	t.Run("sends only the pagination parameters the route honours", func(t *testing.T) {
+		httpmock.Activate()
+		defer httpmock.DeactivateAndReset()
+
+		var capturedQuery string
+		httpmock.RegisterResponder("GET", packDataRoot+"/",
+			func(req *http.Request) (*http.Response, error) {
+				capturedQuery = req.URL.RawQuery
+				body := `{"count":1,"next":null,"previous":null,"results":[` + onePackDataRecord + `]}`
+				return httpmock.NewStringResponse(200, body), nil
+			})
+
+		nc := newPackTestClient(t)
+		resp, err := nc.ListPackData(context.Background(), &client.ListPackDataRequest{
+			Limit:    5,
+			Offset:   10,
+			Ordering: "-created",
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, "limit=5&offset=10&ordering=-created", capturedQuery)
+		assert.Equal(t, 1, resp.Count)
+		require.Len(t, resp.Results, 1)
+		assert.Equal(t, "config", resp.Results[0].ActionType)
+	})
+
+	t.Run("sends no query string at all for the zero request", func(t *testing.T) {
+		httpmock.Activate()
+		defer httpmock.DeactivateAndReset()
+
+		var capturedQuery string
+		httpmock.RegisterResponder("GET", packDataRoot+"/",
+			func(req *http.Request) (*http.Response, error) {
+				capturedQuery = req.URL.RawQuery
+				return httpmock.NewStringResponse(200, emptyPage), nil
+			})
+
+		nc := newPackTestClient(t)
+		_, err := nc.ListPackData(context.Background(), nil)
+
+		require.NoError(t, err)
+		assert.Empty(t, capturedQuery)
+	})
+
+	t.Run("honours a consumer POV", func(t *testing.T) {
+		httpmock.Activate()
+		defer httpmock.DeactivateAndReset()
+
+		httpmock.RegisterResponder("GET", packTestBaseURL+"/v1/external/consumer/pack/data/",
+			httpmock.NewStringResponder(200, emptyPage))
+
+		nc := newPackTestClient(t)
+		_, err := nc.ListPackData(context.Background(), &client.ListPackDataRequest{POV: client.POVConsumer})
+
+		require.NoError(t, err)
 	})
 }

--- a/pkg/client/request.go
+++ b/pkg/client/request.go
@@ -99,6 +99,32 @@ func (c *Client) doRequest(ctx context.Context, method, path string, body any, o
 	return nil
 }
 
+// decodeHistoryList decodes the answer from one of the platform's history routes into entries.
+// The what argument names the resource for the error message ("AI processor", say).
+//
+// Those routes paginate, so entries normally arrive inside the standard envelope. This sniffs
+// the shape rather than assuming it: a view only wraps its results while a paginator is
+// configured, and pagination is an instance-wide setting an on-prem deployment can turn off,
+// which would otherwise leave every history call failing to decode at all.
+func decodeHistoryList[T any](raw json.RawMessage, what string) ([]T, error) {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) > 0 && trimmed[0] == '[' {
+		var entries []T
+		if err := json.Unmarshal(trimmed, &entries); err != nil {
+			return nil, fmt.Errorf("failed to decode %s history: %w", what, err)
+		}
+		return entries, nil
+	}
+
+	var envelope struct {
+		Results []T `json:"results"`
+	}
+	if err := json.Unmarshal(trimmed, &envelope); err != nil {
+		return nil, fmt.Errorf("failed to decode %s history envelope: %w", what, err)
+	}
+	return envelope.Results, nil
+}
+
 // queryParams accumulates list-endpoint filters in the form the NetOrca API expects, and
 // renders them percent-encoded. The zero value is ready to use.
 //

--- a/pkg/client/service_items.go
+++ b/pkg/client/service_items.go
@@ -26,6 +26,13 @@ type GetServiceItemsRequest struct {
 
 	// application_id is the ID of the application
 	ApplicationID string `json:"application_id"`
+	// application_name is the exact name of the application. Comma-join several to get an
+	// "in" lookup (an OR), the same convention the id filters above follow.
+	ApplicationName string `json:"application_name"`
+	// application_name_contains matches applications whose name contains this substring,
+	// case-insensitively. It is deliberately a single value rather than a list: the backend
+	// declares it as a plain icontains filter, so a comma would be matched literally.
+	ApplicationNameContains string `json:"application_name_contains"`
 	// consumer_team_id is the ID of the consumer team
 	ConsumerTeamID string `json:"consumer_team_id"`
 
@@ -43,6 +50,13 @@ type GetServiceItemsRequest struct {
 	// service_owner_team_id is the ID of the service owner team
 	ServiceOwnerTeamID string `json:"service_owner_team_id"`
 
+	// start_date restricts results to items modified at or after this time. Note that the
+	// backend applies both date bounds to modified rather than created, so this asks "changed
+	// since", not "created since" - which is what a reconciler polling for drift wants.
+	StartDate time.Time `json:"start_date"`
+	// end_date restricts results to items modified at or before this time.
+	EndDate time.Time `json:"end_date"`
+
 	// limit is the number of results to return per page
 	Limit int `json:"limit"`
 	// offset is the initial index from which to return the results
@@ -53,6 +67,8 @@ type GetServiceItemsRequest struct {
 
 // ToQueryParams converts the GetServiceItemsRequest to a query string - keys are sorted alphabetically
 // and values are URL encoded.
+//
+//nolint:funlen // one flat branch per filter; splitting it would only hide which filters exist
 func (f *GetServiceItemsRequest) ToQueryParams() (string, error) {
 	params := url.Values{}
 
@@ -70,6 +86,12 @@ func (f *GetServiceItemsRequest) ToQueryParams() (string, error) {
 	}
 	if f.ApplicationID != "" {
 		params.Add("application_id", f.ApplicationID)
+	}
+	if f.ApplicationName != "" {
+		params.Add("application_name", f.ApplicationName)
+	}
+	if f.ApplicationNameContains != "" {
+		params.Add("application_name_contains", f.ApplicationNameContains)
 	}
 	if f.ConsumerTeamID != "" {
 		params.Add("consumer_team_id", f.ConsumerTeamID)
@@ -91,6 +113,12 @@ func (f *GetServiceItemsRequest) ToQueryParams() (string, error) {
 	}
 	if f.ServiceOwnerTeamID != "" {
 		params.Add("service_owner_team_id", f.ServiceOwnerTeamID)
+	}
+	if !f.StartDate.IsZero() {
+		params.Add("start_date", f.StartDate.Format(time.RFC3339))
+	}
+	if !f.EndDate.IsZero() {
+		params.Add("end_date", f.EndDate.Format(time.RFC3339))
 	}
 	if f.Limit > 0 {
 		params.Add("limit", strconv.Itoa(f.Limit))
@@ -181,6 +209,36 @@ func (c *Client) GetServiceItemsWithContext(
 	ctx context.Context,
 	filters *GetServiceItemsRequest,
 ) (*GetServiceItemsResponse, error) {
+	return c.listServiceItems(ctx, filters, "")
+}
+
+// GetDependantServiceItems fetches the service items your team is involved in as a dependant
+// team rather than as their service owner - items whose service belongs to somebody else, but
+// against which your team holds change instances because that service names you in its
+// dependant_teams.
+//
+// The plain listing cannot reach them: it is scoped to the POV's own team, so a dependant team's
+// work is invisible there. This is the route to poll when your team fulfils part of somebody
+// else's service.
+//
+// It takes the same filters and returns the same paginated shape as GetServiceItemsWithContext,
+// with one caveat: the backend swaps the whole filter backend chain on this route, dropping the
+// ordering backend with it, so Ordering is accepted but has no effect here.
+func (c *Client) GetDependantServiceItems(
+	ctx context.Context,
+	filters *GetServiceItemsRequest,
+) (*GetServiceItemsResponse, error) {
+	return c.listServiceItems(ctx, filters, "dependant/")
+}
+
+// listServiceItems performs one service item listing, against either the plain route (an empty
+// action) or one of its extra list routes. They share a filter set and a response shape, so the
+// only thing that varies is the path segment.
+func (c *Client) listServiceItems(
+	ctx context.Context,
+	filters *GetServiceItemsRequest,
+	action string,
+) (*GetServiceItemsResponse, error) {
 	if filters == nil {
 		filters = &GetServiceItemsRequest{}
 	}
@@ -192,7 +250,7 @@ func (c *Client) GetServiceItemsWithContext(
 
 	// The trailing slash is the canonical DRF route; without it the API replies 301 to the
 	// slashed URL, doubling the round trips.
-	endpoint := fmt.Sprintf("orcabase/%s/service_items/", POV(filters.POV).orDefault())
+	endpoint := fmt.Sprintf("orcabase/%s/service_items/%s", POV(filters.POV).orDefault(), action)
 	if params != "" {
 		endpoint += "?" + params
 	}

--- a/pkg/client/service_items_test.go
+++ b/pkg/client/service_items_test.go
@@ -2,7 +2,9 @@
 package client_test
 
 import (
+	"context"
 	"encoding/json"
+	"net/http"
 	"testing"
 	"time"
 
@@ -13,6 +15,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const serviceItemsRoot = packTestBaseURL + "/v1/orcabase/serviceowner/service_items"
+
+// emptyPage is the paginated envelope for a listing that matched nothing. The wire tests care
+// about the request they sent, not the answer, so they all reply with this.
+const emptyPage = `{"count":0,"next":null,"previous":null,"results":[]}`
+
+//nolint:funlen // a filter table: every case has to spell out the fields it is pinning
 func TestGetServiceItemsToQueryParams(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -22,23 +31,27 @@ func TestGetServiceItemsToQueryParams(t *testing.T) {
 		{
 			name: "All fields set",
 			request: &client.GetServiceItemsRequest{
-				Name:                "test",
-				RuntimeState:        "running",
-				ChangeState:         "changed",
-				Declaration:         "declaration",
-				ApplicationID:       "app-id",
-				ConsumerTeamID:      "team-id",
-				DeclarationContains: "contains",
-				DeclarationRegex:    "regex",
-				ServiceID:           "service-id",
-				ServiceName:         "service-name",
-				ServiceOwnerID:      "owner-id",
-				ServiceOwnerTeamID:  "team-owner-id",
-				Limit:               10,
-				Offset:              0,
-				Ordering:            "-created_at",
+				Name:                    "test",
+				RuntimeState:            "running",
+				ChangeState:             "changed",
+				Declaration:             "declaration",
+				ApplicationID:           "app-id",
+				ApplicationName:         "app-name",
+				ApplicationNameContains: "app-nam",
+				ConsumerTeamID:          "team-id",
+				DeclarationContains:     "contains",
+				DeclarationRegex:        "regex",
+				ServiceID:               "service-id",
+				ServiceName:             "service-name",
+				ServiceOwnerID:          "owner-id",
+				ServiceOwnerTeamID:      "team-owner-id",
+				StartDate:               time.Date(2025, 4, 1, 0, 0, 0, 0, time.UTC),
+				EndDate:                 time.Date(2025, 4, 30, 0, 0, 0, 0, time.UTC),
+				Limit:                   10,
+				Offset:                  0,
+				Ordering:                "-created_at",
 			},
-			expected: "application_id=app-id&change_state=changed&consumer_team_id=team-id&declaration=declaration&declaration_contains=contains&declaration_regex=regex&limit=10&name=test&ordering=-created_at&runtime_state=running&service_id=service-id&service_name=service-name&service_owner_id=owner-id&service_owner_team_id=team-owner-id", //nolint
+			expected: "application_id=app-id&application_name=app-name&application_name_contains=app-nam&change_state=changed&consumer_team_id=team-id&declaration=declaration&declaration_contains=contains&declaration_regex=regex&end_date=2025-04-30T00%3A00%3A00Z&limit=10&name=test&ordering=-created_at&runtime_state=running&service_id=service-id&service_name=service-name&service_owner_id=owner-id&service_owner_team_id=team-owner-id&start_date=2025-04-01T00%3A00%3A00Z", //nolint
 		},
 		{
 			name:     "No fields set",
@@ -264,5 +277,114 @@ func TestClientServiceItems(t *testing.T) { //nolint:funlen
 		require.Error(t, err)
 		assert.Nil(t, serviceItems)
 		require.ErrorIs(t, err, client.ErrBadRequest)
+	})
+}
+
+// TestGetServiceItemsFilterWire pins the new filters to the wire. The backend's filterset rejects
+// any parameter it does not declare with a 400, so the names matter as much as the values.
+func TestGetServiceItemsFilterWire(t *testing.T) {
+	t.Run("sends the application name and modified-window filters", func(t *testing.T) {
+		httpmock.Activate()
+		defer httpmock.DeactivateAndReset()
+
+		var capturedQuery string
+		httpmock.RegisterResponder("GET", serviceItemsRoot+"/",
+			func(req *http.Request) (*http.Response, error) {
+				capturedQuery = req.URL.RawQuery
+				return httpmock.NewStringResponse(200, emptyPage), nil
+			})
+
+		nc := newPackTestClient(t)
+		_, err := nc.GetServiceItemsWithContext(context.Background(), &client.GetServiceItemsRequest{
+			ApplicationName:         "app17,app18",
+			ApplicationNameContains: "app1",
+			StartDate:               time.Date(2025, 4, 1, 0, 0, 0, 0, time.UTC),
+			EndDate:                 time.Date(2025, 4, 30, 0, 0, 0, 0, time.UTC),
+		})
+
+		require.NoError(t, err)
+		// A comma-joined value is the platform's "in" lookup, so this asks for either.
+		assert.Contains(t, capturedQuery, "application_name=app17%2Capp18")
+		assert.Contains(t, capturedQuery, "application_name_contains=app1")
+		assert.Contains(t, capturedQuery, "start_date=2025-04-01T00%3A00%3A00Z")
+		assert.Contains(t, capturedQuery, "end_date=2025-04-30T00%3A00%3A00Z")
+	})
+
+	t.Run("omits the date filters when unset", func(t *testing.T) {
+		httpmock.Activate()
+		defer httpmock.DeactivateAndReset()
+
+		var capturedQuery string
+		httpmock.RegisterResponder("GET", serviceItemsRoot+"/",
+			func(req *http.Request) (*http.Response, error) {
+				capturedQuery = req.URL.RawQuery
+				return httpmock.NewStringResponse(200, emptyPage), nil
+			})
+
+		nc := newPackTestClient(t)
+		_, err := nc.GetServiceItemsWithContext(context.Background(), &client.GetServiceItemsRequest{
+			Name: "fastapi",
+		})
+
+		require.NoError(t, err)
+		// A zero time is "unset", not the epoch - sending it would silently exclude
+		// everything modified before 1970, which is to say everything.
+		assert.NotContains(t, capturedQuery, "start_date")
+		assert.NotContains(t, capturedQuery, "end_date")
+	})
+}
+
+func TestGetDependantServiceItems(t *testing.T) {
+	t.Run("queries the dependant route carrying the filters", func(t *testing.T) {
+		httpmock.Activate()
+		defer httpmock.DeactivateAndReset()
+
+		var capturedQuery string
+		httpmock.RegisterResponder("GET", serviceItemsRoot+"/dependant/",
+			func(req *http.Request) (*http.Response, error) {
+				capturedQuery = req.URL.RawQuery
+				return httpmock.NewStringResponse(200, emptyPage), nil
+			})
+
+		nc := newPackTestClient(t)
+		resp, err := nc.GetDependantServiceItems(context.Background(), &client.GetServiceItemsRequest{
+			ApplicationName: "app17",
+			Limit:           50,
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, 0, resp.Count)
+		// The extra route shares the plain listing's filterset, so the filters must survive
+		// the detour rather than being dropped on the way.
+		assert.Contains(t, capturedQuery, "application_name=app17")
+		assert.Contains(t, capturedQuery, "limit=50")
+	})
+
+	t.Run("honours a consumer POV", func(t *testing.T) {
+		httpmock.Activate()
+		defer httpmock.DeactivateAndReset()
+
+		httpmock.RegisterResponder("GET", packTestBaseURL+"/v1/orcabase/consumer/service_items/dependant/",
+			httpmock.NewStringResponder(200, emptyPage))
+
+		nc := newPackTestClient(t)
+		_, err := nc.GetDependantServiceItems(context.Background(), &client.GetServiceItemsRequest{
+			POV: string(client.POVConsumer),
+		})
+
+		require.NoError(t, err)
+	})
+
+	t.Run("defaults an empty POV to serviceowner", func(t *testing.T) {
+		httpmock.Activate()
+		defer httpmock.DeactivateAndReset()
+
+		httpmock.RegisterResponder("GET", serviceItemsRoot+"/dependant/",
+			httpmock.NewStringResponder(200, emptyPage))
+
+		nc := newPackTestClient(t)
+		_, err := nc.GetDependantServiceItems(context.Background(), nil)
+
+		require.NoError(t, err)
 	})
 }


### PR DESCRIPTION
## Why

The Terraform provider is being brought to functional parity with the Ansible collection, and its read surface fell short: several filters the platform accepts had no field on the SDK request structs, so the provider could not offer them.

The sharpest case was **`application_id` on change instances**. The provider accepts it, has no way to send it, and emits a warning while returning **unfiltered** results — a filter that silently does not filter, which is worse than one that is absent.

## Approach

Everything here was checked against the backend filtersets before being written. They extend `LimitedFilterSet`, which answers `400 "Filter param not found."` for any unrecognised query parameter, so a speculative filter is actively harmful. Every addition below cites the line that declares it.

## Filters

**`GetServiceItemsRequest`** — from `ServiceItemFilterSet` (`orcabase/filters.py:195`)

| Field | Param | Line |
|---|---|---|
| `ApplicationName` | `application_name` | 213 |
| `ApplicationNameContains` | `application_name_contains` | 216 |
| `StartDate` / `EndDate` | `start_date` / `end_date` | 235 / 238 |

**`GetChangeInstancesRequest`** — from `ChangeInstanceFilterSet` (`filters.py:332`)

| Field | Param | Line |
|---|---|---|
| `ApplicationID` | `application_id` | 343 |
| `StartDate` / `EndDate` | `start_date` / `end_date` | 378 / 381 |

`start_date`/`end_date` are a bonus — neither the Ansible collection nor the provider exposed them.

## New methods

- `GetDependantServiceItems`, `GetDependantChangeInstances`, `GetReferencedChangeInstances`
- `ListChangeInstanceHistory`
- `GetPackDataByID`, `ListPackData`

`ListChangeInstanceHistory` is deliberately **not** a port of the Python SDK's version, which builds a broken double-id URL (`.../change_instances/{id}/history/{id}/`) that the Ansible collection routes around. A test pins the path.

## Platform behaviours found, documented at the call site

- **The pack data list route has no filterset**, so unknown query params are silently dropped rather than rejected. `ListPackDataRequest` is limit/offset/ordering only, and says why silent-drop is worse than a 400.
- **`dependant` and `referenced` ignore `ordering`** — they override `filter_backends` and drop `OrderingFilter`. Accepted, no effect.
- **The two `dependant` routes point in opposite directions.** `service_items/dependant` lists items where *you* are the dependant team; `change_instances/dependant` lists changes on services *you own* handed to *your* dependants. Easy to get backwards; both godocs state the direction.

Also found but deliberately not added: `include_decommissioned` on service items is bound to `method="noop_dummy"` — accepted, does nothing.

## Refactor

`dupl` flagged the new `ListChangeInstanceHistory` against the existing `ListAIProcessorHistory`; both sides get reported, so silencing it meant touching `ai_processors.go` either way. Extracted a shared `decodeHistoryList` into `request.go` instead. Error strings unchanged, no test asserted on them, `ai_processors.go` net −23 lines.

## Testing

`gofmt` / `go build` / `go vet` / `go test` clean, and `golangci-lint` clean via the CI image with both output caps lifted (`--max-same-issues 0 --max-issues-per-linter 0` — the default caps at 3 per linter and hides the rest).

Tests assert the **outbound query string**, not just decoded responses — the whole point is that these filters reach the wire. That includes `application_id=23%2C24`, comma-joined name lists, both date bounds, and that zero times are omitted rather than sent as the epoch.

Not run: anything against a live instance. The v0.1.2 work is what proved the wire format; this is additive on the same request layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)