### PR TITLE
fix: page through deployed item history instead of scanning one page

### DIFF
--- a/pkg/client/deployed_items.go
+++ b/pkg/client/deployed_items.go
@@ -308,10 +308,11 @@ func (c *Client) GetDeployedItem(ctx context.Context, pov POV, id int) (*Deploye
 // FindDeployedItemForServiceItem returns the current deployed item for a service item.
 //
 // This is the call that reconciles identity. A deployed item's natural key is its parent, not
-// its id, because every accepted write records a new version rather than editing the last
-// one - so a Terraform provider that remembered an id would go on reading a superseded
-// version forever. Looking the current one up by service item is the only stable way to ask
-// "what does the platform think is deployed here".
+// its id: a create cuts a new version rather than editing the last, so a caller that remembered
+// an id from an earlier create would go on reading a superseded version. Looking the current
+// one up by service item is the stable way to ask "what does the platform think is deployed
+// here" - an in-place update rewrites the current version, but which record is current can only
+// be answered by parent.
 //
 // "Current" means the highest version, which is what the platform itself resolves a service
 // item's deployed item to. It returns an error wrapping ErrNotFound when the service item has
@@ -321,30 +322,47 @@ func (c *Client) FindDeployedItemForServiceItem(
 	pov POV,
 	serviceItemID int,
 ) (*DeployedItem, error) {
-	response, err := c.ListDeployedItems(ctx, &ListDeployedItemsRequest{
-		POV:           pov,
-		ServiceItemID: []int{serviceItemID},
-		// Newest first, so the current version lands on the first page even for a service
-		// item with a long history. The scan below does not depend on this being honoured.
-		Ordering: "-version",
-	})
-	if err != nil {
-		return nil, fmt.Errorf(
-			"failed to look up the deployed item for service item %d: %w", serviceItemID, err,
-		)
+	// The current record is the highest version, and a service item's history can run past one
+	// page - 32 versions against a page size of 20 has been seen. Taking the max over a single
+	// page returns a stale version the moment the history outgrows a page, so this pages through
+	// every result and takes the true max. Because it scans everything, the answer does not
+	// depend on the server honouring any particular ordering.
+	const pageSize = 100
+
+	var current *DeployedItem
+	seen := 0
+	for offset := 0; ; offset += pageSize {
+		response, err := c.ListDeployedItems(ctx, &ListDeployedItemsRequest{
+			POV:           pov,
+			ServiceItemID: []int{serviceItemID},
+			Limit:         pageSize,
+			Offset:        offset,
+		})
+		if err != nil {
+			return nil, fmt.Errorf(
+				"failed to look up the deployed item for service item %d: %w", serviceItemID, err,
+			)
+		}
+
+		for index := range response.Results {
+			if current == nil || response.Results[index].Version > current.Version {
+				candidate := response.Results[index]
+				current = &candidate
+			}
+		}
+
+		// Stop on a short page or once every counted item has been read. Guarding on Count as
+		// well as page length means a server that ignores the limit cannot spin this loop.
+		seen += len(response.Results)
+		if len(response.Results) < pageSize || seen >= response.Count {
+			break
+		}
 	}
 
-	if len(response.Results) == 0 {
+	if current == nil {
 		return nil, fmt.Errorf(
 			"%w: no deployed item for service item %d", ErrNotFound, serviceItemID,
 		)
-	}
-
-	current := &response.Results[0]
-	for index := range response.Results {
-		if response.Results[index].Version > current.Version {
-			current = &response.Results[index]
-		}
 	}
 	return current, nil
 }

--- a/pkg/client/deployed_items_test.go
+++ b/pkg/client/deployed_items_test.go
@@ -3,7 +3,9 @@ package client_test
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -303,7 +305,7 @@ func TestFindDeployedItemForServiceItem(t *testing.T) { //nolint:funlen
 		assert.Equal(t, 3, item.Version)
 	})
 
-	t.Run("filters by service item and asks for the newest first", func(t *testing.T) {
+	t.Run("filters by service item", func(t *testing.T) {
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
 
@@ -322,7 +324,41 @@ func TestFindDeployedItemForServiceItem(t *testing.T) { //nolint:funlen
 
 		require.NoError(t, err)
 		assert.Contains(t, capturedQuery, "service_item_id=389")
-		assert.Contains(t, capturedQuery, "ordering=-version")
+	})
+
+	t.Run("finds the highest version when the history spans more than one page", func(t *testing.T) {
+		httpmock.Activate()
+		defer httpmock.DeactivateAndReset()
+
+		// The history is longer than one page and, deliberately, unordered: the highest version
+		// sits on the second page. Taking the max over the first page alone - the bug this test
+		// guards - would return the stale v20 as current.
+		var page1 []string
+		for v := 1; v <= 100; v++ {
+			page1 = append(page1, fmt.Sprintf(
+				`{"id":%d,"version":%d,"service_item":"%s"}`, 7000+v, v, serviceItemLink))
+		}
+		current := fmt.Sprintf(
+			`{"id":9999,"version":132,"service_item":"%s"}`, serviceItemLink)
+
+		httpmock.RegisterResponder("GET", deployedItemsRoot+"/",
+			func(req *http.Request) (*http.Response, error) {
+				body := `{"count":101,"results":[` + current + `]}`
+				if req.URL.Query().Get("offset") == "" || req.URL.Query().Get("offset") == "0" {
+					body = `{"count":101,"results":[` + joinJSON(page1) + `]}`
+				}
+				return httpmock.NewStringResponse(200, body), nil
+			})
+
+		nc := newDeployedItemTestClient(t)
+		item, err := nc.FindDeployedItemForServiceItem(
+			context.Background(), client.POVServiceOwner, 389,
+		)
+
+		require.NoError(t, err)
+		require.NotNil(t, item)
+		assert.Equal(t, 132, item.Version, "the current version is on the second page")
+		assert.Equal(t, 9999, item.ID)
 	})
 
 	t.Run("returns ErrNotFound when nothing is deployed", func(t *testing.T) {
@@ -615,4 +651,9 @@ func TestDeleteDeployedItem(t *testing.T) {
 		require.Error(t, err)
 		require.ErrorIs(t, err, client.ErrNotFound)
 	})
+}
+
+// joinJSON joins pre-rendered JSON object literals with commas, for building a results array.
+func joinJSON(parts []string) string {
+	return strings.Join(parts, ",")
 }


### PR DESCRIPTION
## Why

`FindDeployedItemForServiceItem` asked for `ordering=-version` and took the max over a **single page**, with a comment claiming the scan did not depend on the ordering being honoured.

It does. A service item with more history than one page - 32 versions against a page size of 20 has been seen - has its current version on a later page, so max-over-page-one returns a stale version as current. The caller then manages a superseded record with no error. Worse, the guard *looked* defended, so nothing would catch it if `ordering` were ever dropped or renamed.

## Fix

Page through every result and take the true max - correct regardless of server-side ordering - and guard the loop on `Count` as well as page length so a server that ignores the limit cannot spin it.

Also corrects the doc comment that said "every accepted write records a new version": a create cuts a new version, an update rewrites the current one in place.

## Test

A new subtest builds a two-page history with the highest version deliberately on the second page and unordered - exactly what the old single-page scan missed.

`go build`, `go vet`, `go test` and `golangci-lint` (CI image) all clean.

## Note

This wants a **v0.1.4** tag so the Terraform provider can pin to it - the provider currently pins the v0.1.3 tag and moves up once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)